### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "node _SERVER/system/server.js"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Run on Repl.it](https://repl.it/badge/github/soupy-developer/auroraOS)](https://repl.it/github/soupy-developer/auroraOS)
+
 # auroraOS
 A window manager/desktop environment in your browser.
 


### PR DESCRIPTION
This pull request adds a  badge to the . This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).
NOTE: this is just a mirror version of this GitHub repo.